### PR TITLE
error correction

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -382,7 +382,7 @@ objectType</td>
 </tr>
 <tr class="even">
 <td><strong>Table ID</strong></td>
-<td>rubrik_dataset_archive_job_events</td>
+<td>rubrik_dataset_archive_events</td>
 </tr>
 <tr class="odd">
 <td><strong>Fields</strong></td>


### PR DESCRIPTION
There is an error leading to no display for somee of the archive graphs. Indeed, the name "rubrik_dataset_archive_job_events" is false and shaall be replaced by "rubrik_dataset_archive_events". After this the graphs display perfectly.

# Description

Please describe your pull request in detail.

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

_Please link to the issue here_

## Motivation and Context

Why is this change required? What problem does it solve?

## How Has This Been Tested?

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-addon-for-splunk/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
